### PR TITLE
Don't kill other jupyter processes on startup.

### DIFF
--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -223,41 +223,6 @@ function createJupyterServer(userId: string, remainingAttempts: number) {
     });
 }
 
-function listJupyterServers(): number[] {
-  var psStdout = '';
-  try {
-    psStdout = childProcess.execSync('ps -C jupyter-notebook -o pid=', {}).toString();
-  } catch (err) {
-    // In the default case, where there are no jupyter-notebook processes running,
-    // the 'ps' call will throw an error. We distinguish that case by ignoring
-    // the error unless the stdout or stderr values are non-empty.
-    if (err['stdout'] != '' || err['stderr'] != '') {
-      throw err;
-    }
-  }
-
-  var jupyterProcesses: number[] = [];
-  var jupyterProcessIdStrings = psStdout.split('\n');
-  for (var i in jupyterProcessIdStrings) {
-    if (jupyterProcessIdStrings[i]) {
-      var processId = parseInt(jupyterProcessIdStrings[i]);
-      if (processId != NaN) {
-        jupyterProcesses.push(processId);
-      }
-    }
-  }
-  return jupyterProcesses;
-}
-
-function killAllJupyterServers() {
-  var jupyterProcesses = listJupyterServers();
-  for (var i in jupyterProcesses) {
-    var processId = jupyterProcesses[i];
-    logging.getLogger().info('Killing abandoned Jupyter notebook process: %d', processId);
-    process.kill(processId);
-  }
-}
-
 export function getPort(request: http.ServerRequest): number {
   var userId = userManager.getUserId(request);
   var server = jupyterServers[userId];
@@ -317,8 +282,6 @@ export function startForUser(userId: string, cb: common.Callback0) {
  */
 export function init(settings: common.AppSettings): void {
   appSettings = settings;
-
-  killAllJupyterServers();
 }
 
 /**


### PR DESCRIPTION
This code existed to prevent multiple datalab processes from running on the
same user-owned VM. However, for our use cases, we control the container where
this code runs, so there's no need to kill other processes (and we prefer not
to for testing).

PTAL @fischman @blois 